### PR TITLE
refactor: Use Application Keys instead of SDK Access Tokens for some API calls

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,10 +1,7 @@
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
 
 name: Continuous integration
-on:
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 jobs:
   validate:
     name: Validate acklo Node.js SDK
@@ -50,5 +47,5 @@ jobs:
 
       - name: Test (integration)
         env:
-          ACKLO_INTEGRATION_TEST_TOKEN: ${{ secrets.ACKLO_INTEGRATION_TEST_TOKEN }}
+          ACKLO_INTEGRATION_TEST_APP_KEY: ${{ secrets.ACKLO_INTEGRATION_TEST_APP_KEY }}
         run: yarn test:integration

--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ yarn add @acklo/node-sdk
 ```js
 // index.js
 const acklo = new require("@acklo/node-sdk").AckloClient({
-  applicationName: "my-app",
+  applicationKey: "[YOUR APPLICATION KEY]",
   environmentName: "local",
-  accessToken: "[Your SDK access token]",
 });
 
 await acklo.connect();

--- a/docs/publishing_to_npm.md
+++ b/docs/publishing_to_npm.md
@@ -6,25 +6,28 @@ yarn npm publish
 ```
 
 Once a new version has been published, the following steps should be taken:
+
 1. A [GitHub release](https://github.com/acklo/node-sdk/releases/new) should be
-    created using this template:
-   
-    ~~~md
-    [Brief description]
-   
-    ## What's changed?
-   
-    [List of PRs included in release]
-    - [PR name] ([PR number with link])
+   created using this template:
 
-    ---
+   ````md
+   [Brief description]
 
-    Also published to [npm](https://www.npmjs.com/package/@acklo/node-sdk). Install with:
+   ## What's changed?
 
-    ```
-    npm install "@acklo/node-sdk@~[New version]"
-    # or
-    yarn add "@acklo/node-sdk@~[New version]"
-    ```
-    ~~~
+   [List of PRs included in release]
+
+   - [PR name] ([PR number with link])
+
+   ---
+
+   Also published to [npm](https://www.npmjs.com/package/@acklo/node-sdk). Install with:
+
+   ```
+   npm install "@acklo/node-sdk@~[New version]"
+   # or
+   yarn add "@acklo/node-sdk@~[New version]"
+   ```
+   ````
+
 1. TypeDoc documentation should be [regenerated](./typedoc.md).

--- a/examples/express-server/README.md
+++ b/examples/express-server/README.md
@@ -1,0 +1,18 @@
+# acklo express-server example
+
+This is an example of how to use acklo to remotely manage configuration for a Node.js Express application.
+
+## Running the example
+
+1. Sign up to [acklo](https://acklo.app) and create an application.
+1. Replace `[YOUR APPLICATION KEY]` with your application's key in `index.js`.
+1. Install dependencies:
+   ```shell
+   npm install
+   ```
+1. Start the server:
+   ```shell
+   npm start
+   ```
+1. Start making changes to the app's config on the acklo UI and you'll see them
+   get applied live!

--- a/examples/express-server/index.js
+++ b/examples/express-server/index.js
@@ -2,9 +2,8 @@ const express = require("express");
 const AckloClient = require("@acklo/node-sdk").AckloClient;
 
 const acklo = new AckloClient({
-  applicationName: "acklo-express-server-example",
+  applicationKey: "[YOUR APPLICATION KEY]",
   environmentName: "local",
-  // accessToken: "[YOUR ACCESS TOKEN]",
 });
 
 acklo

--- a/examples/express-server/index.js
+++ b/examples/express-server/index.js
@@ -1,37 +1,44 @@
 const express = require("express");
 const AckloClient = require("@acklo/node-sdk").AckloClient;
 
+// Instantiate the SDK
 const acklo = new AckloClient({
   applicationKey: "[YOUR APPLICATION KEY]",
   environmentName: "local",
 });
 
-acklo
-  .connect()
-  .then(() => console.log("Connected to acklo!"))
-  .catch((err) => console.error("Failed to connect to acklo", err));
+async function main() {
+  // Connect to acklo to retrieve the latest config and stay in sync with
+  // any config updates.
+  await acklo.connect();
 
-const app = express();
+  // Get some config values from acklo.
+  const port = acklo.get("config.port");
+  const messageOfTheDay = acklo.get("config.motd");
 
-const port = acklo.get("config.port");
-const motd = acklo.get("config.motd");
+  const app = express();
 
-app.get("/", (_, res) => {
-  if (acklo.get("switches.maximize_excitement")) {
-    res.json({ motd: `${motd}!!!!!!!!!!!` });
-  } else {
-    res.json({ motd });
-  }
-});
+  app.get("/", (_, res) => {
+    if (acklo.get("switches.maximize_excitement")) {
+      res.json({ motd: `${messageOfTheDay}!!!!!!!!!!!` });
+    } else {
+      res.json({ motd: messageOfTheDay });
+    }
+  });
 
-let server = app.listen(port);
-console.log(`Listening on port ${port}`);
+  let server = app.listen(port);
+  console.log(`Listening on port ${port}`);
 
-acklo.onConfigUpdate((updates) => {
-  if (updates["config.port"]) {
-    const newPort = updates["config.port"].newValue;
-    server.close();
-    server = app.listen(newPort);
-    console.log(`Changed port to ${newPort}`);
-  }
-});
+  acklo.onConfigUpdate((updates) => {
+    if (updates["config.port"]) {
+      const newPort = updates["config.port"].newValue;
+      server.close();
+      server = app.listen(newPort);
+      console.log(`Changed port to ${newPort}`);
+    }
+  });
+}
+
+main()
+  .then(() => console.log("Initialized server"))
+  .catch((err) => console.error(`Error initializing server: ${err}.`));

--- a/examples/express-server/package-lock.json
+++ b/examples/express-server/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@acklo/node-sdk": {
-      "version": "0.2.0-pre1",
-      "resolved": "https://registry.npmjs.org/@acklo/node-sdk/-/node-sdk-0.2.0-pre1.tgz",
-      "integrity": "sha512-KIr1U99NRH8NU52hBi5aXUG1WBLfEz+L7ww9Wk+1WQ7sFDKU7sb4Qn/uMrznb18QuUTfo7kHh9ZF2a1X375VXQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@acklo/node-sdk/-/node-sdk-0.2.0.tgz",
+      "integrity": "sha512-AsjUTa7rEKdRmsQ3NhN7ThDK2jy6P5tU1IAc6XhvfGbHJq6L0yfcgEDLdGLpeH1gLrJTcGcYCNyGMQgiyVXHrg==",
       "requires": {
         "axios": "^0.21.0",
         "backo2": "^1.0.2",

--- a/examples/express-server/package-lock.json
+++ b/examples/express-server/package-lock.json
@@ -1,0 +1,463 @@
+{
+  "name": "@acklo/example-express-server",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@acklo/node-sdk": {
+      "version": "0.2.0-pre1",
+      "resolved": "https://registry.npmjs.org/@acklo/node-sdk/-/node-sdk-0.2.0-pre1.tgz",
+      "integrity": "sha512-KIr1U99NRH8NU52hBi5aXUG1WBLfEz+L7ww9Wk+1WQ7sFDKU7sb4Qn/uMrznb18QuUTfo7kHh9ZF2a1X375VXQ==",
+      "requires": {
+        "axios": "^0.21.0",
+        "backo2": "^1.0.2",
+        "chalk": "^4.1.0",
+        "tslib": "^2.0.3",
+        "ws": "^7.4.6",
+        "yaml": "^2.0.0-1"
+      }
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      }
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
+    },
+    "mime-types": {
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "requires": {
+        "mime-db": "1.48.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "ws": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.2.tgz",
+      "integrity": "sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ=="
+    },
+    "yaml": {
+      "version": "2.0.0-6",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-6.tgz",
+      "integrity": "sha512-YPUm0Z0sei53zauT7HWkkxyIBJhb9Gnf5jv4w4ahw5/v3PjFGhZOt4paXH6g9hzcMJqmNxZwoGfF1JzE2jvSgg=="
+    }
+  }
+}

--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -4,7 +4,10 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@acklo/node-sdk": "^0.0.21",
+    "@acklo/node-sdk": "^0.2.0-pre1",
     "express": "^4.17.1"
+  },
+  "scripts": {
+    "start": "node index.js"
   }
 }

--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@acklo/node-sdk": "^0.2.0-pre1",
+    "@acklo/node-sdk": "^0.2.0",
     "express": "^4.17.1"
   },
   "scripts": {

--- a/examples/typescript-hello-world/README.md
+++ b/examples/typescript-hello-world/README.md
@@ -1,0 +1,25 @@
+# acklo typescript-hello-world example
+
+This is an example of how to use acklo to remotely manage configuration
+of a Node.js CLI application written in TypeScript.
+
+## Running the example
+
+1. Sign up to [acklo](https://acklo.app) and create an application.
+1. Replace `[YOUR APPLICATION KEY]` with your application's key in `index.ts`.
+1. Install dependencies:
+   ```shell
+   npm install
+   ```
+1. Run the CLI app:
+
+   ```shell
+   yarn start
+
+   # Or
+
+   yarn start Bobby
+   ```
+
+1. Start making changes to the app's config on the acklo UI and you'll see them
+   get applied live!

--- a/examples/typescript-hello-world/index.ts
+++ b/examples/typescript-hello-world/index.ts
@@ -2,10 +2,9 @@ import { AckloClient } from "@acklo/node-sdk";
 
 async function main(name = "there") {
   const acklo = await new AckloClient({
-    applicationName: "acklo-typescript-hello-world-example",
+    applicationKey: "[YOUR APPLICATION KEY]",
     environmentName: "local",
     logLevel: "off",
-    // accessToken: "[YOUR ACCESS TOKEN]",
   }).connect();
 
   console.log(`${acklo.get("config.greeting")} ${name}`);

--- a/examples/typescript-hello-world/index.ts
+++ b/examples/typescript-hello-world/index.ts
@@ -1,12 +1,14 @@
 import { AckloClient } from "@acklo/node-sdk";
 
 async function main(name = "there") {
+  // Instantiate the acklo client
   const acklo = await new AckloClient({
     applicationKey: "[YOUR APPLICATION KEY]",
     environmentName: "local",
     logLevel: "off",
   }).connect();
 
+  // Get a config property
   console.log(`${acklo.get("config.greeting")} ${name}`);
 
   await acklo.disconnect();

--- a/examples/typescript-hello-world/package-lock.json
+++ b/examples/typescript-hello-world/package-lock.json
@@ -1,0 +1,197 @@
+{
+  "name": "@acklo/example-typescript-hello-world",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@acklo/node-sdk": {
+      "version": "0.2.0-pre1",
+      "resolved": "https://registry.npmjs.org/@acklo/node-sdk/-/node-sdk-0.2.0-pre1.tgz",
+      "integrity": "sha512-KIr1U99NRH8NU52hBi5aXUG1WBLfEz+L7ww9Wk+1WQ7sFDKU7sb4Qn/uMrznb18QuUTfo7kHh9ZF2a1X375VXQ==",
+      "requires": {
+        "axios": "^0.21.0",
+        "backo2": "^1.0.2",
+        "chalk": "^4.1.0",
+        "tslib": "^2.0.3",
+        "ws": "^7.4.6",
+        "yaml": "^2.0.0-1"
+      }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
+      "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "ts-node": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
+      "integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
+      "dev": true,
+      "requires": {
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
+    "tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
+    "typescript": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "dev": true
+    },
+    "ws": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.2.tgz",
+      "integrity": "sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ=="
+    },
+    "yaml": {
+      "version": "2.0.0-6",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-6.tgz",
+      "integrity": "sha512-YPUm0Z0sei53zauT7HWkkxyIBJhb9Gnf5jv4w4ahw5/v3PjFGhZOt4paXH6g9hzcMJqmNxZwoGfF1JzE2jvSgg=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    }
+  }
+}

--- a/examples/typescript-hello-world/package-lock.json
+++ b/examples/typescript-hello-world/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@acklo/node-sdk": {
-      "version": "0.2.0-pre1",
-      "resolved": "https://registry.npmjs.org/@acklo/node-sdk/-/node-sdk-0.2.0-pre1.tgz",
-      "integrity": "sha512-KIr1U99NRH8NU52hBi5aXUG1WBLfEz+L7ww9Wk+1WQ7sFDKU7sb4Qn/uMrznb18QuUTfo7kHh9ZF2a1X375VXQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@acklo/node-sdk/-/node-sdk-0.2.0.tgz",
+      "integrity": "sha512-AsjUTa7rEKdRmsQ3NhN7ThDK2jy6P5tU1IAc6XhvfGbHJq6L0yfcgEDLdGLpeH1gLrJTcGcYCNyGMQgiyVXHrg==",
       "requires": {
         "axios": "^0.21.0",
         "backo2": "^1.0.2",

--- a/examples/typescript-hello-world/package.json
+++ b/examples/typescript-hello-world/package.json
@@ -8,7 +8,7 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "@acklo/node-sdk": "^0.0.21"
+    "@acklo/node-sdk": "^0.2.0-pre1"
   },
   "scripts": {
     "start": "ts-node index.ts"

--- a/examples/typescript-hello-world/package.json
+++ b/examples/typescript-hello-world/package.json
@@ -8,7 +8,7 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "@acklo/node-sdk": "^0.2.0-pre1"
+    "@acklo/node-sdk": "^0.2.0"
   },
   "scripts": {
     "start": "ts-node index.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acklo/node-sdk",
-  "version": "0.2.0-pre1",
+  "version": "0.2.0",
   "description": "Node.js SDK for https://acklo.app",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "homepage": "https://acklo.app",
   "bugs": "https://github.com/acklo/node-sdk/issues",
   "license": "Apache-2.0",
-  "private": false,
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "docs:generate": "rm -rf docs_website && typedoc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acklo/node-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0-pre1",
   "description": "Node.js SDK for https://acklo.app",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/AckloClient.ts
+++ b/src/AckloClient.ts
@@ -8,9 +8,8 @@
  * ```js
  * // Create a new instance
  * const acklo = new AckloClient({
- *   applicationName: "my-app",
- *   environmentName: "local",
- *   accessToken: "acklo-123"
+ *   applicationKey: "[YOUR APPLICATION KEY]",
+ *   environmentName: "local"
  * });
  *
  * // Connect to acklo
@@ -65,9 +64,8 @@ const packageVersion = require("../package.json").version;
  * ```js
  * // Create a new instance
  * const acklo = new AckloClient({
- *   applicationName: "my-app",
- *   environmentName: "local",
- *   accessToken: "acklo-123"
+ *   applicationKey: "[YOUR APPLICATION KEY]",
+ *   environmentName: "local"
  * });
  *
  * // Connect to acklo
@@ -101,9 +99,8 @@ export class AckloClient {
    * ```js
    * // Create the instance
    * const acklo = new AckloClient({
-   *   applicationName: "my-app",
-   *   environmentName: "local",
-   *   accessToken: "acklo-123"
+   *   applicationKey: "[YOUR APPLICATION KEY]",
+   *   environmentName: "local"
    * });
    *
    * // This will be the default port configured in your acklo configuration file.
@@ -150,17 +147,15 @@ export class AckloClient {
    * ```js
    * // Using async/await
    * const acklo = await new AckloClient({
-   *   applicationName: "my-app",
-   *   environmentName: "local",
-   *   accessToken: "acklo-123"
+   *   applicationKey: "[YOUR APPLICATION KEY]",
+   *   environmentName: "local"
    * }).connect();
    *
    * // Using promises
    * const acklo =
    *   new AckloClient({
-   *     applicationName: "my-app",
-   *     environmentName: "local",
-   *     accessToken: "acklo-123"
+   *     applicationKey: "[YOUR APPLICATION KEY]",
+   *     environmentName: "local"
    *   })
    *  .connect()
    *  .then(() => console.log("Connected successfully"))
@@ -195,7 +190,7 @@ export class AckloClient {
         : {};
 
       this.instance = await this.apiClient.createInstance(
-        this.clientConfiguration.applicationName,
+        this.clientConfiguration.applicationKey,
         this.clientConfiguration.environmentName,
         this.configTemplate.toJSON(),
         this.configTemplate.rawContent,
@@ -204,10 +199,14 @@ export class AckloClient {
       );
 
       this.configTemplate.updateValues(
-        await this.apiClient.getInstanceConfiguration(this.instance.id)
+        await this.apiClient.getInstanceConfiguration(
+          this.clientConfiguration.applicationKey,
+          this.instance.id
+        )
       );
 
       this.heartbeatSender = new HeartbeatSender(
+        this.clientConfiguration.applicationKey,
         this.instance.id,
         this.apiClient,
         this.clientConfiguration.heartbeatInterval
@@ -225,7 +224,11 @@ export class AckloClient {
         this.clientConfiguration.webSocketBaseUrl
       );
       this.webSocketConnection.addHandler(
-        new CommandExecutionHandler(this.configTemplate, this.apiClient)
+        new CommandExecutionHandler(
+          this.clientConfiguration.applicationKey,
+          this.configTemplate,
+          this.apiClient
+        )
       );
       await this.webSocketConnection.connect(this.instance.id);
 
@@ -260,9 +263,8 @@ export class AckloClient {
    * @example
    * ```js
    * const acklo = await new AckloClient({
-   *   applicationName: "my-app",
-   *   environmentName: "local",
-   *   accessToken: "acklo-123"
+   *   applicationKey: "[YOUR APPLICATION KEY]",
+   *   environmentName: "local"
    * }).connect();
    *
    * await acklo.disconnect();

--- a/src/ClientConfiguration.ts
+++ b/src/ClientConfiguration.ts
@@ -21,32 +21,19 @@ export type LogLevel = "off" | "error" | "warn" | "info" | "debug";
  * @example
  * ```js
  * {
- *   applicationName: "my-web-service",
+ *   applicationKey: "[YOUR APPLICATION KEY]",
  *   environmentName: "development"
  * }
  * ```
  */
 export interface ClientConfigurationProperties {
   /**
-   * The SDK access token for your acklo workspace. This is used to authenticate
-   * your application's access to your acklo workspace.
+   * Your application's unique key. This is used to identify this application by the SDK.
    *
-   * This token should be treated as a secret, so please don't commit it to your
-   * source code. Instead prefer injecting it via an environment variable.
-   *
-   * This can also be configured by setting the `ACKLO_ACCESS_TOKEN` environment
+   * This value can also be configured by setting the `ACKLO_APPLICATION_KEY` environment
    * variable.
    */
-  accessToken: string;
-
-  /**
-   * The name of your application. This is used to identify your application within
-   * your acklo workspace.
-   *
-   * This value can also be configured by setting the `ACKLO_APPLICATION_NAME` environment
-   * variable.
-   */
-  applicationName: string;
+  applicationKey: string;
 
   /**
    * The name of your application's environment. This is used to identify which environment
@@ -94,6 +81,22 @@ export interface ClientConfigurationProperties {
   autoTags: boolean;
 
   /**
+   * The SDK access token for your acklo workspace. This is used to authenticate
+   * your application's access to your acklo workspace.
+   *
+   * Note: this property is not yet generally available for use.
+   *
+   * This token should be treated as a secret, so please don't commit it to your
+   * source code. Instead prefer injecting it via an environment variable.
+   *
+   * This can also be configured by setting the `ACKLO_ACCESS_TOKEN` environment
+   * variable.
+   *
+   * @private
+   */
+  accessToken: string;
+
+  /**
    * The name of the locally stored profile to use for authenticating to acklo.
    *
    * Note: this property is not yet generally available for use.
@@ -107,8 +110,8 @@ export interface ClientConfigurationProperties {
 
 export class ClientConfiguration {
   readonly profile: ProfileName;
-  readonly accessToken: string;
-  readonly applicationName: string;
+  readonly accessToken: string | undefined;
+  readonly applicationKey: string;
   readonly environmentName: string;
   readonly logLevel: LogLevel;
   readonly tags: Tags;
@@ -130,19 +133,16 @@ export class ClientConfiguration {
 
     const profile = rcFile.profile(this.profile);
 
-    const accessToken =
+    this.accessToken =
       environment["ACKLO_ACCESS_TOKEN"] ||
       config.accessToken ||
       profile?.accessToken;
-    accessToken
-      ? (this.accessToken = accessToken)
-      : configErrors.push("accessToken");
 
-    const applicationName =
-      environment["ACKLO_APPLICATION_NAME"] || config.applicationName;
-    applicationName
-      ? (this.applicationName = applicationName)
-      : configErrors.push("applicationName");
+    const applicationKey =
+      environment["ACKLO_APPLICATION_KEY"] || config.applicationKey;
+    applicationKey
+      ? (this.applicationKey = applicationKey)
+      : configErrors.push("applicationKey");
 
     const environmentName =
       environment["ACKLO_ENVIRONMENT_NAME"] || config.environmentName;
@@ -173,6 +173,9 @@ export class ClientConfiguration {
   }
 }
 
+/**
+ * @private
+ */
 export function isLogLevel(thing: unknown): thing is LogLevel {
   if (typeof thing === "string") {
     return ["off", "error", "info", "debug"].includes(thing);

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -51,8 +51,7 @@ export class MissingRequiredConfigurationValuesError extends HumanReadableError 
 }
 
 /**
- * Failed to connect to acklo. This is usually due to an invalid SDK access token
- * being provided.
+ * Failed to connect to acklo. This is usually due to invalid authentication.
  */
 export class ConnectionError extends HumanReadableError {
   constructor(underlyingError?: Error) {

--- a/src/HeartbeatSender.ts
+++ b/src/HeartbeatSender.ts
@@ -16,6 +16,7 @@ export class HeartbeatSender {
   events = new EventEmitter();
 
   constructor(
+    private readonly applicationKey: string,
     private readonly instanceId: string,
     private readonly apiClient: ApiClient,
     private readonly heartbeatInterval: number
@@ -61,7 +62,7 @@ export class HeartbeatSender {
     this.cancelTokenSource = axios.CancelToken.source();
 
     this.apiClient
-      .sendInstanceHeartbeatWithRetries(this.instanceId, {
+      .sendInstanceHeartbeatWithRetries(this.applicationKey, this.instanceId, {
         cancelToken: this.cancelTokenSource.token,
       })
       .catch((err) => {

--- a/src/__tests__/AckloClient.integration.ts
+++ b/src/__tests__/AckloClient.integration.ts
@@ -5,10 +5,12 @@ import { configureGlobalLoggerInstance } from "../Logger";
 import { stderr } from "process";
 import { mocked } from "ts-jest/utils";
 
-const TOKEN_ENV_VAR = "ACKLO_INTEGRATION_TEST_TOKEN";
-const token = process.env[TOKEN_ENV_VAR];
-if (!token) {
-  throw new Error(`Need ${TOKEN_ENV_VAR} env var set to run integration tests`);
+const APP_KEY_ENV_VAR = "ACKLO_INTEGRATION_TEST_APP_KEY";
+const applicationKey = process.env[APP_KEY_ENV_VAR];
+if (!applicationKey) {
+  throw new Error(
+    `Need ${APP_KEY_ENV_VAR} env var set to run integration tests`
+  );
 }
 
 describe("acklo (integration)", () => {
@@ -40,9 +42,8 @@ describe("acklo (integration)", () => {
 
     it("connects to the acklo api and retrieves config values", async () => {
       const instance = new AckloClient({
-        applicationName: "sdk-test-target",
-        environmentName: "integration-test",
-        accessToken: token,
+        applicationKey: applicationKey,
+        environmentName: "production",
       });
 
       expect(instance.getConfig()).toMatchInlineSnapshot(`
@@ -84,7 +85,7 @@ describe("acklo (integration)", () => {
 
       expect(instance.getInstanceName()).toMatch(/^ins-\w+-\w+-\w+$/);
       expect(instance.getInstanceUrl()).toMatch(
-        /^http.*applications\/sdk-test-target\/integration-test\/instances\/.*$/
+        /^http.*applications\/sdk-test-target\/production\/instances\/.*$/
       );
 
       await expect(instance.disconnect()).resolves.toBeInstanceOf(AckloClient);
@@ -97,9 +98,8 @@ describe("acklo (integration)", () => {
 
     it("returns defaults when the api cannot be reached", async () => {
       const instance = new AckloClient({
-        applicationName: "sdk-test-target",
-        environmentName: "integration-test",
-        accessToken: "not-a-valid-token",
+        applicationKey: "invalid-application-key",
+        environmentName: "production",
       });
 
       await expect(instance.connect()).resolves.toBe(instance);
@@ -119,7 +119,7 @@ describe("acklo (integration)", () => {
       expect(loggedLines.filter((l) => l.indexOf("acklo:error") > -1))
         .toMatchInlineSnapshot(`
       Array [
-        "[acklo:error] An invalid access token has been provided. Please configure your SDK with a valid access token.
+        "[acklo:error] An invalid application key has been provided. Please check your SDK's configuration.
       ",
       ]
     `);
@@ -144,9 +144,8 @@ describe("acklo (integration)", () => {
       stderrMock.mockReset();
 
       new AckloClient({
-        applicationName: "sdk-test-target",
-        environmentName: "integration-test",
-        accessToken: token,
+        applicationKey: applicationKey,
+        environmentName: "production",
       });
 
       expect(stderrMock.mock.calls[0]).toMatchSnapshot();

--- a/src/__tests__/ApiClient.spec.ts
+++ b/src/__tests__/ApiClient.spec.ts
@@ -27,7 +27,7 @@ describe("ApiClient", () => {
 
   describe("createInstance", () => {
     it("returns the instance details when a successful api request is made", async () => {
-      const applicationName = "app";
+      const applicationKey = "acklo.app.4xdjucrpl33thaxxolRw";
       const environmentName = "env";
       const rawConfigTemplateContent = YAML.stringify({ hey: "test" });
       const configTemplateContent = JSON.stringify(
@@ -44,23 +44,26 @@ describe("ApiClient", () => {
       mockedAxios.post.mockResolvedValueOnce({ data: response });
 
       const res = await apiClient.createInstance(
-        applicationName,
+        applicationKey,
         environmentName,
         configTemplateContent,
         rawConfigTemplateContent,
         "1.0.0"
       );
 
-      expect(mockedAxios.post).toHaveBeenCalledWith("/instances", {
-        application_name: applicationName,
-        environment_name: environmentName,
-        raw_config_template_content: rawConfigTemplateContent,
-        config_template_content: configTemplateContent,
-        config_template_content_type: "application/json",
-        sdk_name: "node-sdk",
-        sdk_version: "1.0.0",
-        tags: {},
-      });
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        "/instances",
+        {
+          environment_name: environmentName,
+          raw_config_template_content: rawConfigTemplateContent,
+          config_template_content: configTemplateContent,
+          config_template_content_type: "application/json",
+          sdk_name: "node-sdk",
+          sdk_version: "1.0.0",
+          tags: {},
+        },
+        { headers: { "x-acklo-app-key": applicationKey } }
+      );
 
       expect(res.id).toEqual(instanceId);
     });

--- a/src/__tests__/ClientConfiguration.spec.ts
+++ b/src/__tests__/ClientConfiguration.spec.ts
@@ -6,7 +6,7 @@ describe("ClientConfiguration", () => {
     const providedConfig = { accessToken: "should-be-overriden" };
     const envVars = {
       ACKLO_ACCESS_TOKEN: "abc-123",
-      ACKLO_APPLICATION_NAME: "my-app",
+      ACKLO_APPLICATION_KEY: "acklo.app.4xdjucrpl33thaxxolRw",
       ACKLO_ENVIRONMENT_NAME: "my-env",
       ACKLO_PROFILE: "dev",
     };
@@ -16,7 +16,7 @@ describe("ClientConfiguration", () => {
       ClientConfiguration {
         "accessToken": "abc-123",
         "apiBaseUrl": "https://acklo.app/api",
-        "applicationName": "my-app",
+        "applicationKey": "acklo.app.4xdjucrpl33thaxxolRw",
         "autoTags": true,
         "environmentName": "my-env",
         "heartbeatInterval": 60000,
@@ -41,7 +41,7 @@ describe("ClientConfiguration", () => {
         `[Error: Missing required configuration properties]`
       );
       expect(err.humanReadableMessage).toMatchInlineSnapshot(
-        `"Missing values for required configuration properties: [applicationName, environmentName]. Please make sure to either provide as arguments to the acklo() constructor function, or as environment variables."`
+        `"Missing values for required configuration properties: [applicationKey, environmentName]. Please make sure to either provide as arguments to the acklo() constructor function, or as environment variables."`
       );
     }
     /* eslint-enable jest/no-conditional-expect, jest/no-try-expect */

--- a/src/__tests__/HeartbeatSender.spec.ts
+++ b/src/__tests__/HeartbeatSender.spec.ts
@@ -6,6 +6,7 @@ import { HeartbeatFailedError } from "../Errors";
 jest.useFakeTimers();
 
 describe("HeartbeatSender", () => {
+  const applicationKey = "acklo.app.4xdjucrpl33thaxxolRw";
   const instanceId = "abc123";
   const heartbeatInterval = 5_000;
 
@@ -15,6 +16,7 @@ describe("HeartbeatSender", () => {
   beforeEach(() => {
     apiClient = new ApiClient("", "");
     heartbeatSender = new HeartbeatSender(
+      applicationKey,
       instanceId,
       apiClient,
       heartbeatInterval
@@ -35,6 +37,7 @@ describe("HeartbeatSender", () => {
 
     expect(apiClient.sendInstanceHeartbeatWithRetries).toHaveBeenCalledTimes(1);
     expect(apiClient.sendInstanceHeartbeatWithRetries).toHaveBeenCalledWith(
+      applicationKey,
       instanceId,
       {
         cancelToken: expect.any(Axios.CancelToken),

--- a/src/handlers/CommandExecutionHandler.ts
+++ b/src/handlers/CommandExecutionHandler.ts
@@ -9,6 +9,7 @@ export class CommandExecutionHandler
   kind = MessageKind.CommandExecution;
 
   constructor(
+    private readonly applicationKey: string,
     private readonly configTemplate: ConfigTemplateFile,
     private readonly apiClient: ApiClient
   ) {}
@@ -16,7 +17,10 @@ export class CommandExecutionHandler
   async handle(message: CommandExecutionMessage): Promise<void> {
     if (message.command.kind === "config_update") {
       const updates = this.configTemplate.updateValues(
-        await this.apiClient.getInstanceConfiguration(message.instanceId)
+        await this.apiClient.getInstanceConfiguration(
+          this.applicationKey,
+          message.instanceId
+        )
       );
 
       if (Object.keys(updates).length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ export interface ApiInstanceResponse {
 }
 
 export interface ApiCreateInstance {
-  application_name: string;
   environment_name: string;
   raw_config_template_content: string;
   config_template_content: string;

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,7 +2,8 @@
   "entryPoints": [
     "src/AckloClient.ts",
     "src/Errors.ts",
-    "src/ConfigTemplate.ts"
+    "src/ConfigTemplate.ts",
+    "src/ClientConfiguration.ts"
   ],
   "exclude": ["**/__tests__/**", "src/test/**"],
   "tsconfig": "tsconfig.build.json",


### PR DESCRIPTION
Whereas SDK access tokens gave unrestricted access to an entire workspace, application keys are scoped to a single application within acklo. The backend is moving towards them in order to provide better security, and a more straightforward onboarding experience.

API calls about an instance's lifecycle (e.g. creating an instance, heartbeating, getting a configuration) will now use application keys for auth. Other endpoints (like ones powering setup token functionality, which is yet to be released) will still use SDK access tokens.